### PR TITLE
fix: Resolve "imported and not used" errors in service tests

### DIFF
--- a/internal/services/medical_record_service_test.go
+++ b/internal/services/medical_record_service_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/google/uuid"
 )
 
+// Compile-time check to ensure MockMedicalRecordRepository implements MedicalRecordRepositoryContract
+var _ repositories.MedicalRecordRepositoryContract = (*MockMedicalRecordRepository)(nil)
+
 // MockMedicalRecordRepository is a mock implementation of MedicalRecordRepositoryContract.
 type MockMedicalRecordRepository struct {
 	CreateFunc            func(ctx context.Context, record *entities.MedicalRecord) error

--- a/internal/services/patient_service_test.go
+++ b/internal/services/patient_service_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/google/uuid"
 )
 
+// Compile-time check to ensure MockPatientRepository implements PatientRepositoryContract
+var _ repositories.PatientRepositoryContract = (*MockPatientRepository)(nil)
+
 // MockPatientRepository is a mock implementation of PatientRepositoryContract.
 type MockPatientRepository struct {
 	CreateFunc      func(ctx context.Context, patient *entities.Patient) error


### PR DESCRIPTION
This commit fixes the "imported and not used" errors for the `medical-record-service/internal/domain/repositories` package in the service test files.

The issue was resolved by adding a compile-time assertion in each test file to ensure the mock repository struct correctly implements the corresponding repository contract interface. This explicitly "uses" the imported repositories package.

Changes:
- In `internal/services/patient_service_test.go`: Added `var _ repositories.PatientRepositoryContract = (*MockPatientRepository)(nil)`
- In `internal/services/medical_record_service_test.go`: Added `var _ repositories.MedicalRecordRepositoryContract = (*MockMedicalRecordRepository)(nil)`

These changes should allow the CI pipeline tests to build and run successfully.

## Summary by Sourcery

Fix test compilation errors by adding compile-time interface assertions in service tests to ensure mock repositories implement their corresponding repository contracts.

Bug Fixes:
- Resolve "imported and not used" errors in patient and medical record service test files.

Tests:
- Add compile-time interface compliance checks for MockPatientRepository in patient_service_test.go.
- Add compile-time interface compliance checks for MockMedicalRecordRepository in medical_record_service_test.go.